### PR TITLE
[API] Milestone 01: Complete Categories Complete CRUD

### DIFF
--- a/src/app/(backend)/routes/categories/handlers.ts
+++ b/src/app/(backend)/routes/categories/handlers.ts
@@ -1,0 +1,463 @@
+import { and, desc, eq, ilike, sql } from "drizzle-orm";
+import * as HttpStatusCodes from "stoker/http-status-codes";
+import * as HttpStatusPhrases from "stoker/http-status-phrases";
+
+import type { AppRouteHandler } from "@/lib/types/server";
+
+import { db } from "@/database";
+import { categories } from "@/database/schema";
+import type {
+  ListCategoriesRoute,
+  CreateCategoryRoute,
+  GetCategoryByIdRoute,
+  DeleteCategoryRoute,
+  UpdateCategoryRoute,
+  ReorderCategoriesRoute
+} from "./routes";
+import { SelectCategoryT } from "@/lib/zod/categories.zod";
+
+// List categories route handler
+export const list: AppRouteHandler<ListCategoriesRoute> = async (c) => {
+  try {
+    const { page = "1", limit = "10", search } = c.req.valid("query");
+
+    // Convert to numbers and validate
+    const pageNum = Math.max(1, parseInt(page));
+    const limitNum = Math.max(1, Math.min(100, parseInt(limit))); // Cap at 100 items
+    const offset = (pageNum - 1) * limitNum;
+
+    // Build search condition for query
+    const searchCondition = search
+      ? and(
+          ilike(categories.name, `%${search}%`)
+          // Add more conditions if needed (e.g., description, slug)
+        )
+      : undefined;
+
+    // Build query with conditions
+    const query = db.query.categories.findMany({
+      limit: limitNum,
+      offset,
+      where: searchCondition,
+      orderBy: (fields) => {
+        return [fields.displayOrder, desc(fields.createdAt)];
+      },
+      with: {
+        subcategories: {
+          orderBy: (fields) => [fields.displayOrder, desc(fields.createdAt)],
+          with: { ogImage: true }
+        },
+        ogImage: true
+      }
+    });
+
+    // Get total count for pagination
+    const totalCountQuery = db
+      .select({ count: sql<number>`count(*)` })
+      .from(categories)
+      .where(searchCondition);
+
+    const [categoryEntries, totalEntries] = await Promise.all([
+      query,
+      totalCountQuery
+    ]);
+
+    const totalCount = totalEntries[0]?.count || 0;
+
+    // Calculate pagination pages metadata
+    const totalPages = Math.ceil(totalCount / limitNum);
+
+    return c.json(
+      {
+        data: categoryEntries.map((category) => ({
+          ...category,
+          description: category.description || null,
+          opengraphImage: category.ogImage || undefined,
+          displayOrder: category.displayOrder || undefined,
+          subcategories: category.subcategories.map((sub) => ({
+            ...sub,
+            description: sub.description || null,
+            opengraphImage: sub.ogImage || undefined,
+            displayOrder: sub.displayOrder || undefined
+          })) as SelectCategoryT["subcategories"]
+        })),
+        meta: {
+          currentPage: pageNum,
+          totalPages,
+          totalCount,
+          limit: limitNum
+        }
+      },
+      HttpStatusCodes.OK
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+// Get category by ID handler
+export const getById: AppRouteHandler<GetCategoryByIdRoute> = async (c) => {
+  try {
+    const params = c.req.valid("param");
+    const categoryId = params.id;
+
+    const category = await db.query.categories.findFirst({
+      where: eq(categories.id, categoryId),
+      with: {
+        subcategories: {
+          orderBy: (fields) => [fields.displayOrder, desc(fields.createdAt)],
+          with: { ogImage: true }
+        },
+        ogImage: true
+      }
+    });
+
+    if (!category) {
+      return c.json(
+        { message: HttpStatusPhrases.NOT_FOUND },
+        HttpStatusCodes.NOT_FOUND
+      );
+    }
+
+    return c.json(
+      {
+        ...category,
+        description: category.description || null,
+        opengraphImage: category.ogImage || undefined,
+        displayOrder: category.displayOrder || undefined,
+        subcategories: category.subcategories.map((sub) => ({
+          ...sub,
+          description: sub.description || null,
+          opengraphImage: sub.ogImage || undefined,
+          displayOrder: sub.displayOrder || undefined
+        })) as SelectCategoryT["subcategories"]
+      } as SelectCategoryT,
+      HttpStatusCodes.OK
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+// Create category handler
+export const create: AppRouteHandler<CreateCategoryRoute> = async (c) => {
+  try {
+    const session = c.get("session");
+    const user = c.get("user");
+
+    if (!session || !user) {
+      return c.json(
+        { message: HttpStatusPhrases.UNAUTHORIZED },
+        HttpStatusCodes.UNAUTHORIZED
+      );
+    }
+
+    //   Check user role
+    if (user.role !== "admin") {
+      if (user.role !== "contentEditor") {
+        return c.json(
+          { message: HttpStatusPhrases.FORBIDDEN },
+          HttpStatusCodes.FORBIDDEN
+        );
+      }
+    }
+
+    const body = c.req.valid("json");
+
+    //   Create new category
+    const newCategory = await db
+      .insert(categories)
+      .values({
+        ...body
+      })
+      .returning();
+
+    if (!newCategory || !newCategory[0])
+      throw new Error("Failed to create category");
+
+    //   Select the newly created category with relations
+    const createdCategory = await db.query.categories.findFirst({
+      where: eq(categories.id, newCategory[0].id),
+      with: {
+        subcategories: {
+          orderBy: (fields) => [fields.displayOrder, desc(fields.createdAt)],
+          with: { ogImage: true }
+        },
+        ogImage: true
+      }
+    });
+
+    if (!createdCategory)
+      throw new Error("Failed to retrieve created category");
+
+    return c.json(
+      {
+        ...createdCategory,
+        description: createdCategory.description || null,
+        opengraphImage: createdCategory.ogImage || undefined,
+        displayOrder: createdCategory.displayOrder || undefined,
+        subcategories: createdCategory.subcategories.map((sub) => ({
+          ...sub,
+          description: sub.description || null,
+          opengraphImage: sub.ogImage || undefined,
+          displayOrder: sub.displayOrder || undefined
+        })) as SelectCategoryT["subcategories"]
+      } as SelectCategoryT,
+      HttpStatusCodes.CREATED
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+// Update category handler
+export const update: AppRouteHandler<UpdateCategoryRoute> = async (c) => {
+  try {
+    const session = c.get("session");
+    const user = c.get("user");
+
+    if (!session || !user) {
+      return c.json(
+        { message: HttpStatusPhrases.UNAUTHORIZED },
+        HttpStatusCodes.UNAUTHORIZED
+      );
+    }
+
+    //   Check user role
+    if (user.role !== "admin") {
+      if (user.role !== "contentEditor") {
+        return c.json(
+          { message: HttpStatusPhrases.FORBIDDEN },
+          HttpStatusCodes.FORBIDDEN
+        );
+      }
+    }
+
+    const params = c.req.valid("param");
+    const body = c.req.valid("json");
+
+    const categoryId = params.id;
+
+    //   Check if category exists
+    const existingCategory = await db.query.categories.findFirst({
+      where: eq(categories.id, categoryId)
+    });
+
+    if (!existingCategory) {
+      return c.json(
+        { message: HttpStatusPhrases.NOT_FOUND },
+        HttpStatusCodes.NOT_FOUND
+      );
+    }
+
+    //   Update category
+    const updatedCategories = await db
+      .update(categories)
+      .set({
+        ...body
+      })
+      .where(eq(categories.id, categoryId))
+      .returning();
+
+    if (!updatedCategories || !updatedCategories[0]) {
+      throw new Error("Failed to update category");
+    }
+
+    //   Select the updated category with relations
+    const updatedCategory = await db.query.categories.findFirst({
+      where: eq(categories.id, updatedCategories[0].id),
+      with: {
+        subcategories: {
+          orderBy: (fields) => [fields.displayOrder, desc(fields.createdAt)],
+          with: { ogImage: true }
+        },
+        ogImage: true
+      }
+    });
+
+    if (!updatedCategory) {
+      throw new Error("Failed to retrieve updated category");
+    }
+
+    return c.json(
+      {
+        ...updatedCategory,
+        description: updatedCategory.description || null,
+        opengraphImage: updatedCategory.ogImage || undefined,
+        displayOrder: updatedCategory.displayOrder || undefined,
+        subcategories: updatedCategory.subcategories.map((sub) => ({
+          ...sub,
+          description: sub.description || null,
+          opengraphImage: sub.ogImage || undefined,
+          displayOrder: sub.displayOrder || undefined
+        })) as SelectCategoryT["subcategories"]
+      } as SelectCategoryT,
+      HttpStatusCodes.OK
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+// Delete category handler
+export const remove: AppRouteHandler<DeleteCategoryRoute> = async (c) => {
+  try {
+    const session = c.get("session");
+    const user = c.get("user");
+
+    if (!session || !user) {
+      return c.json(
+        { message: HttpStatusPhrases.UNAUTHORIZED },
+        HttpStatusCodes.UNAUTHORIZED
+      );
+    }
+
+    //   Check user role
+    if (user.role !== "admin") {
+      if (user.role !== "contentEditor") {
+        return c.json(
+          { message: HttpStatusPhrases.FORBIDDEN },
+          HttpStatusCodes.FORBIDDEN
+        );
+      }
+    }
+
+    const params = c.req.valid("param");
+    const categoryId = params.id;
+
+    //   Check if category exists
+    const existingCategory = await db.query.categories.findFirst({
+      where: eq(categories.id, categoryId)
+    });
+
+    if (!existingCategory) {
+      return c.json(
+        { message: HttpStatusPhrases.NOT_FOUND },
+        HttpStatusCodes.NOT_FOUND
+      );
+    }
+
+    //   Delete category
+    await db.delete(categories).where(eq(categories.id, categoryId));
+
+    return c.json(
+      { message: "Category successfully deleted" },
+      HttpStatusCodes.OK
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};
+
+// Reorder categories handler
+
+// Example:
+/**
+
+// Batch update all priority indices
+const updates = body.items.map((item) =>
+    db
+    .update(education)
+    .set({ priorityIndex: item.priorityIndex, updatedAt: new Date() })
+    .where(eq(education.id, item.id))
+);
+
+console.log({ updates });
+
+await Promise.all(updates);
+
+*/
+
+export const reorder: AppRouteHandler<ReorderCategoriesRoute> = async (c) => {
+  try {
+    const session = c.get("session");
+    const user = c.get("user");
+
+    if (!session || !user) {
+      return c.json(
+        { message: HttpStatusPhrases.UNAUTHORIZED },
+        HttpStatusCodes.UNAUTHORIZED
+      );
+    }
+
+    //   Check user role
+    if (user.role !== "admin") {
+      if (user.role !== "contentEditor") {
+        return c.json(
+          { message: HttpStatusPhrases.FORBIDDEN },
+          HttpStatusCodes.FORBIDDEN
+        );
+      }
+    }
+
+    const body = c.req.valid("json");
+
+    //   Validate all IDs exist
+    const categoryIds = body.items.map((item) => item.id);
+
+    const existingCategories = await db.query.categories.findMany({
+      where: (fields, { inArray }) => inArray(fields.id, categoryIds)
+    });
+
+    //   Check if all categories exist
+    if (existingCategories.length !== categoryIds.length) {
+      return c.json(
+        { message: HttpStatusPhrases.NOT_FOUND },
+        HttpStatusCodes.NOT_FOUND
+      );
+    }
+
+    //   Update category order
+    const updates = body.items.map((item) =>
+      db
+        .update(categories)
+        .set({ displayOrder: item.displayOrder, updatedAt: new Date() })
+        .where(eq(categories.id, item.id))
+    );
+
+    await Promise.all(updates);
+
+    return c.json(
+      { message: "Categories successfully reordered" },
+      HttpStatusCodes.OK
+    );
+  } catch (error) {
+    return c.json(
+      {
+        message:
+          (error as Error).message || HttpStatusPhrases.INTERNAL_SERVER_ERROR
+      },
+      HttpStatusCodes.INTERNAL_SERVER_ERROR
+    );
+  }
+};

--- a/src/app/(backend)/routes/categories/index.ts
+++ b/src/app/(backend)/routes/categories/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from "@/lib/server/create-app";
+
+import * as handlers from "./handlers";
+import * as routes from "./routes";
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.getById, handlers.getById)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.update, handlers.update)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/app/(backend)/routes/categories/index.ts
+++ b/src/app/(backend)/routes/categories/index.ts
@@ -8,6 +8,7 @@ const router = createRouter()
   .openapi(routes.getById, handlers.getById)
   .openapi(routes.create, handlers.create)
   .openapi(routes.update, handlers.update)
-  .openapi(routes.remove, handlers.remove);
+  .openapi(routes.remove, handlers.remove)
+  .openapi(routes.reorder, handlers.reorder);
 
 export default router;

--- a/src/app/(backend)/routes/categories/routes.ts
+++ b/src/app/(backend)/routes/categories/routes.ts
@@ -1,0 +1,216 @@
+import { createRoute } from "@hono/zod-openapi";
+import * as HttpStatusCodes from "stoker/http-status-codes";
+import { jsonContent, jsonContentRequired } from "stoker/openapi/helpers";
+import { z } from "zod";
+
+import {
+  errorMessageSchema,
+  getPaginatedSchema,
+  queryParamsSchema,
+  stringIdParamSchema
+} from "@/lib/server/helpers";
+import {
+  createCategorySchema,
+  selectCategorySchema,
+  updateCategorySchema
+} from "@/lib/zod/categories.zod";
+import { reorderItemsSchema } from "@/lib/helpers";
+
+const tags: string[] = ["Categories"];
+
+// List all categories route definition
+export const list = createRoute({
+  tags,
+  summary: "List all categories",
+  path: "/",
+  method: "get",
+  request: {
+    query: queryParamsSchema
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      getPaginatedSchema(z.array(selectCategorySchema)),
+      "List of categories with pagination and populated subcategories"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Internal server error"
+    )
+  }
+});
+
+// Get category by ID route definition
+export const getById = createRoute({
+  tags,
+  summary: "Get category by ID",
+  path: "/:id",
+  method: "get",
+  request: {
+    params: stringIdParamSchema
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      selectCategorySchema,
+      "The category item with populated subcategories"
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      errorMessageSchema,
+      "Category not found"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Internal server error"
+    )
+  }
+});
+
+// Create category route definition
+export const create = createRoute({
+  tags,
+  summary: "Create a new category",
+  path: "/",
+  method: "post",
+  request: {
+    body: jsonContentRequired(
+      createCategorySchema,
+      "New category request body payload"
+    )
+  },
+  responses: {
+    [HttpStatusCodes.CREATED]: jsonContent(
+      selectCategorySchema,
+      "The created category with populated subcategories"
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(
+      errorMessageSchema,
+      "Invalid request payload"
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
+      errorMessageSchema,
+      "Unauthorized access"
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      errorMessageSchema,
+      "Forbidden access"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Internal server error"
+    )
+  }
+});
+
+// Update category route definition
+export const update = createRoute({
+  tags,
+  summary: "Update an existing category",
+  path: "/:id",
+  method: "put",
+  request: {
+    params: stringIdParamSchema,
+    body: jsonContentRequired(
+      updateCategorySchema,
+      "Update category request body payload"
+    )
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      selectCategorySchema,
+      "The updated category with populated subcategories"
+    ),
+    [HttpStatusCodes.BAD_REQUEST]: jsonContent(
+      errorMessageSchema,
+      "Invalid request payload"
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      errorMessageSchema,
+      "Category not found"
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
+      errorMessageSchema,
+      "Unauthorized access"
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      errorMessageSchema,
+      "Forbidden access"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Internal server error"
+    )
+  }
+});
+
+// Delete category route definition
+export const remove = createRoute({
+  tags,
+  summary: "Delete a category",
+  path: "/:id",
+  method: "delete",
+  request: {
+    params: stringIdParamSchema
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      errorMessageSchema, // For send error message
+      "Category successfully deleted"
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      errorMessageSchema,
+      "Category not found"
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
+      errorMessageSchema,
+      "Unauthorized access"
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      errorMessageSchema,
+      "Forbidden access"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Internal server error"
+    )
+  }
+});
+
+// Reorder categories route definition
+export const reorder = createRoute({
+  tags,
+  summary: "Reorder categories",
+  method: "patch",
+  path: "/reorder",
+  request: {
+    body: jsonContentRequired(reorderItemsSchema, "Reorder education items")
+  },
+  responses: {
+    [HttpStatusCodes.OK]: jsonContent(
+      errorMessageSchema, // For send success message
+      "Categories reordered successfully"
+    ),
+    [HttpStatusCodes.UNAUTHORIZED]: jsonContent(
+      errorMessageSchema,
+      "Unauthorized access"
+    ),
+    [HttpStatusCodes.FORBIDDEN]: jsonContent(
+      errorMessageSchema,
+      "Forbidden access"
+    ),
+    [HttpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      errorMessageSchema,
+      "Failed to reorder education items"
+    ),
+    [HttpStatusCodes.NOT_FOUND]: jsonContent(
+      errorMessageSchema,
+      "Category not found"
+    )
+  }
+});
+
+// Route Type Definitions
+export type ListCategoriesRoute = typeof list;
+export type GetCategoryByIdRoute = typeof getById;
+export type CreateCategoryRoute = typeof create;
+export type UpdateCategoryRoute = typeof update;
+export type DeleteCategoryRoute = typeof remove;
+export type ReorderCategoriesRoute = typeof reorder;

--- a/src/app/(backend)/routes/registry.ts
+++ b/src/app/(backend)/routes/registry.ts
@@ -5,9 +5,13 @@ import { BASE_API_PATH } from "@/lib/config/constants";
 
 import tasks from "./tasks";
 import media from "./media";
+import categories from "./categories";
 
 export function registerRoutes(app: AppOpenAPI) {
-  return app.route("/tasks", tasks).route("/media", media);
+  return app
+    .route("/tasks", tasks)
+    .route("/media", media)
+    .route("/categories", categories);
 }
 
 // stand alone router type used for api client

--- a/src/database/migrations/0005_cynical_redwing.sql
+++ b/src/database/migrations/0005_cynical_redwing.sql
@@ -1,0 +1,42 @@
+CREATE TABLE "categories" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"description" text,
+	"display_order" integer DEFAULT 0,
+	"seo_title" text,
+	"seo_description" text,
+	"og_image_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "categories_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "categories_display_order_check" CHECK ("categories"."display_order" > 0)
+);
+--> statement-breakpoint
+CREATE TABLE "subcategories" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"category_id" text,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"description" text,
+	"display_order" integer DEFAULT 0,
+	"seo_title" text,
+	"seo_description" text,
+	"og_image_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "subcategories_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "subcategories_category_id_slug_unique" UNIQUE("category_id","slug"),
+	CONSTRAINT "categories_display_order_check" CHECK ("subcategories"."display_order" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "categories" ADD CONSTRAINT "categories_og_image_id_media_id_fk" FOREIGN KEY ("og_image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subcategories" ADD CONSTRAINT "subcategories_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "subcategories" ADD CONSTRAINT "subcategories_og_image_id_media_id_fk" FOREIGN KEY ("og_image_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "categories_slug_idx" ON "categories" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "categories_display_order_idx" ON "categories" USING btree ("display_order");--> statement-breakpoint
+CREATE INDEX "categories_name_idx" ON "categories" USING btree ("name");--> statement-breakpoint
+CREATE INDEX "categories_id_idx" ON "categories" USING btree ("id");--> statement-breakpoint
+CREATE INDEX "subcategories_category_id_idx" ON "subcategories" USING btree ("category_id");--> statement-breakpoint
+CREATE INDEX "subcategories_display_order_idx" ON "subcategories" USING btree ("display_order");--> statement-breakpoint
+CREATE INDEX "subcategories_name_idx" ON "subcategories" USING btree ("name");

--- a/src/database/migrations/0006_remarkable_dust.sql
+++ b/src/database/migrations/0006_remarkable_dust.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "categories" DROP CONSTRAINT "categories_display_order_check";--> statement-breakpoint
+ALTER TABLE "subcategories" DROP CONSTRAINT "categories_display_order_check";--> statement-breakpoint
+ALTER TABLE "categories" ADD CONSTRAINT "categories_display_order_check" CHECK ("categories"."display_order" >= 0);--> statement-breakpoint
+ALTER TABLE "subcategories" ADD CONSTRAINT "subcategories_display_order_check" CHECK ("subcategories"."display_order" >= 0);

--- a/src/database/migrations/meta/0005_snapshot.json
+++ b/src/database/migrations/meta/0005_snapshot.json
@@ -1,0 +1,848 @@
+{
+  "id": "e38195a5-c8b4-4e21-8af9-b3f906c9d637",
+  "prevId": "ed570450-56af-41b0-990b-8cd3aba1f371",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tasks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seo_keywords": {
+          "name": "seo_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_user_id_fk": {
+          "name": "media_uploaded_by_user_id_fk",
+          "tableFrom": "media",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_id": {
+          "name": "og_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_display_order_idx": {
+          "name": "categories_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_name_idx": {
+          "name": "categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_id_idx": {
+          "name": "categories_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_og_image_id_media_id_fk": {
+          "name": "categories_og_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "og_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "categories_display_order_check": {
+          "name": "categories_display_order_check",
+          "value": "\"categories\".\"display_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_id": {
+          "name": "og_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subcategories_category_id_idx": {
+          "name": "subcategories_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subcategories_display_order_idx": {
+          "name": "subcategories_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subcategories_name_idx": {
+          "name": "subcategories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subcategories_category_id_categories_id_fk": {
+          "name": "subcategories_category_id_categories_id_fk",
+          "tableFrom": "subcategories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subcategories_og_image_id_media_id_fk": {
+          "name": "subcategories_og_image_id_media_id_fk",
+          "tableFrom": "subcategories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "og_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subcategories_slug_unique": {
+          "name": "subcategories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "subcategories_category_id_slug_unique": {
+          "name": "subcategories_category_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "categories_display_order_check": {
+          "name": "categories_display_order_check",
+          "value": "\"subcategories\".\"display_order\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/0006_snapshot.json
+++ b/src/database/migrations/meta/0006_snapshot.json
@@ -1,0 +1,848 @@
+{
+  "id": "eb0f3ca1-a96a-42d6-83bf-6dd1ab223c4b",
+  "prevId": "e38195a5-c8b4-4e21-8af9-b3f906c9d637",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "tasks_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "seo_keywords": {
+          "name": "seo_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_uploaded_by_user_id_fk": {
+          "name": "media_uploaded_by_user_id_fk",
+          "tableFrom": "media",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_id": {
+          "name": "og_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_display_order_idx": {
+          "name": "categories_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_name_idx": {
+          "name": "categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_id_idx": {
+          "name": "categories_id_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_og_image_id_media_id_fk": {
+          "name": "categories_og_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "og_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "categories_display_order_check": {
+          "name": "categories_display_order_check",
+          "value": "\"categories\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subcategories": {
+      "name": "subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "seo_title": {
+          "name": "seo_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_description": {
+          "name": "seo_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "og_image_id": {
+          "name": "og_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subcategories_category_id_idx": {
+          "name": "subcategories_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subcategories_display_order_idx": {
+          "name": "subcategories_display_order_idx",
+          "columns": [
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subcategories_name_idx": {
+          "name": "subcategories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subcategories_category_id_categories_id_fk": {
+          "name": "subcategories_category_id_categories_id_fk",
+          "tableFrom": "subcategories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subcategories_og_image_id_media_id_fk": {
+          "name": "subcategories_og_image_id_media_id_fk",
+          "tableFrom": "subcategories",
+          "tableTo": "media",
+          "columnsFrom": [
+            "og_image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subcategories_slug_unique": {
+          "name": "subcategories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "subcategories_category_id_slug_unique": {
+          "name": "subcategories_category_id_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "category_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "subcategories_display_order_check": {
+          "name": "subcategories_display_order_check",
+          "value": "\"subcategories\".\"display_order\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1759641852055,
       "tag": "0005_cynical_redwing",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1759663221312,
+      "tag": "0006_remarkable_dust",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1759485894755,
       "tag": "0004_adorable_timeslip",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1759641852055,
+      "tag": "0005_cynical_redwing",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schema/categories.schema.ts
+++ b/src/database/schema/categories.schema.ts
@@ -39,8 +39,8 @@ export const categories = pgTable(
     index("categories_name_idx").on(t.name),
     index("categories_id_idx").on(t.id),
 
-    // Ensure display order is positive
-    check("categories_display_order_check", sql`${t.displayOrder} > 0`)
+    // Ensure display order is non-negative
+    check("categories_display_order_check", sql`${t.displayOrder} >= 0`)
   ]
 );
 
@@ -78,8 +78,8 @@ export const subcategories = pgTable(
     index("subcategories_display_order_idx").on(t.displayOrder),
     index("subcategories_name_idx").on(t.name),
 
-    // Ensure display order is positive
-    check("categories_display_order_check", sql`${t.displayOrder} > 0`)
+    // Ensure display order is non-negative
+    check("subcategories_display_order_check", sql`${t.displayOrder} >= 0`)
   ]
 );
 

--- a/src/database/schema/categories.schema.ts
+++ b/src/database/schema/categories.schema.ts
@@ -84,11 +84,19 @@ export const subcategories = pgTable(
 );
 
 // Relationships
-export const categoriesRelations = relations(categories, ({ many }) => ({
+export const categoriesRelations = relations(categories, ({ many, one }) => ({
+  ogImage: one(media, {
+    fields: [categories.og_image_id],
+    references: [media.id]
+  }),
   subcategories: many(subcategories)
 }));
 
 export const subcategoriesRelations = relations(subcategories, ({ one }) => ({
+  ogImage: one(media, {
+    fields: [subcategories.og_image_id],
+    references: [media.id]
+  }),
   category: one(categories, {
     fields: [subcategories.categoryId],
     references: [categories.id]

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,6 +1,8 @@
 import { sql } from "drizzle-orm";
 import { timestamp } from "drizzle-orm/pg-core";
 
+import { z } from "zod";
+
 // ---------- Database Helpers ----------
 export const timestamps = {
   createdAt: timestamp("created_at").defaultNow().notNull(),
@@ -27,3 +29,13 @@ export function toKebabCase(str: string) {
       .replace(/-+/g, "-")
   );
 }
+
+// --------- Reorder Schema -----------
+export const reorderItemsSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.string(),
+      displayOrder: z.number().int().min(0)
+    })
+  )
+});

--- a/src/lib/zod/categories.zod.ts
+++ b/src/lib/zod/categories.zod.ts
@@ -25,7 +25,7 @@ export const subcategoryBaseSchema = z.object({
 
   name: z.string().min(1).max(255),
   slug: z.string().min(1).max(255),
-  description: z.string(),
+  description: z.string().nullable(),
 
   displayOrder: z.number().min(0).default(0),
 
@@ -49,7 +49,7 @@ export const selectSubcategorySchema = subcategoryBaseSchema
   .omit({ ogImageId: true })
   .extend({
     parent: categoryBaseSchema.optional(),
-    opengraphImage: mediaSchema
+    opengraphImage: mediaSchema.optional()
   });
 
 // Select category schema

--- a/src/lib/zod/categories.zod.ts
+++ b/src/lib/zod/categories.zod.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { mediaSchema } from "./media.zod";
+
+export const categoryBaseSchema = z.object({
+  id: z.string(),
+
+  name: z.string().min(1).max(255),
+  slug: z.string().min(1).max(255),
+  description: z.string().nullable(),
+
+  displayOrder: z.number().min(0).default(0),
+
+  // SEO Fields
+  seoTitle: z.string().nullable(),
+  seoDescription: z.string().nullable(),
+  ogImageId: z.string().nullable(),
+
+  createdAt: z.date().nullable(),
+  updatedAt: z.date().nullable()
+});
+
+export const subcategoryBaseSchema = z.object({
+  id: z.string(),
+  categoryId: z.string().nullable(),
+
+  name: z.string().min(1).max(255),
+  slug: z.string().min(1).max(255),
+  description: z.string(),
+
+  displayOrder: z.number().min(0).default(0),
+
+  // SEO Fields
+  seoTitle: z.string().nullable(),
+  seoDescription: z.string().nullable(),
+  ogImageId: z.string().nullable(),
+
+  updatedAt: z.date().nullable(),
+  createdAt: z.date().nullable()
+});
+
+export type CategoryBaseT = z.infer<typeof categoryBaseSchema>;
+export type SubcategoryBaseT = z.infer<typeof subcategoryBaseSchema>;
+
+// Select subcategory schema
+// Populate fields:
+// - [opengraphImage]
+// - [category] as parent as baseCategorySchema
+export const selectSubcategorySchema = subcategoryBaseSchema
+  .omit({ ogImageId: true })
+  .extend({
+    parent: categoryBaseSchema.optional(),
+    opengraphImage: mediaSchema
+  });
+
+// Select category schema
+// Populate Fields:
+// - [opengraphImage]
+// - [subcategories] as array of selectSubcategorySchema
+export const selectCategorySchema = categoryBaseSchema
+  .omit({ ogImageId: true })
+  .extend({
+    subcategories: z.array(selectSubcategorySchema).optional(),
+    opengraphImage: mediaSchema.optional()
+  });
+
+// Create Category Schema
+export const createCategorySchema = categoryBaseSchema.omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+  displayOrder: true
+});
+
+// Create Subcategory Schema
+export const createSubcategorySchema = subcategoryBaseSchema
+  .omit({
+    id: true,
+    createdAt: true,
+    updatedAt: true,
+    categoryId: true,
+    displayOrder: true
+  })
+  .extend({
+    parentCategoryId: z.string().min(1).max(255)
+  });
+
+// Update Category Schema
+export const updateCategorySchema = createCategorySchema.partial();
+
+// Update Subcategory Schema
+export const updateSubcategorySchema = createSubcategorySchema.partial();
+
+// Inffered Type Definitions
+export type SelectCategoryT = z.infer<typeof selectCategorySchema>;
+export type SelectSubcategoryT = z.infer<typeof selectSubcategorySchema>;
+
+export type CreateCategoryT = z.infer<typeof createCategorySchema>;
+export type CreateSubcategoryT = z.infer<typeof createSubcategorySchema>;
+
+export type UpdateCategoryT = z.infer<typeof updateCategorySchema>;
+export type UpdateSubcategoryT = z.infer<typeof updateSubcategorySchema>;


### PR DESCRIPTION
This pull request introduces a comprehensive backend implementation for managing categories and subcategories, including database schema, API routes, and validation schemas. The changes add full CRUD support, ordering, and OpenAPI integration for categories, as well as proper data validation and relationship management.

The most important changes are:

**Database Schema and Migrations**
- Added new tables `categories` and `subcategories` with all relevant fields, foreign key relationships, constraints, and indexes. The schema enforces unique slugs, non-negative display order, and links to media for Open Graph images.
- Updated the display order constraints in both tables to allow zero as a valid value (was previously only positive).
- Updated the migration journal to include these new migrations.

**API Routes and Routing**
- Implemented a new set of RESTful API routes for categories using OpenAPI and Zod validation, supporting list, get by ID, create, update, delete, and reorder operations.
- Registered the new categories router in the main backend route registry, making the endpoints accessible under `/categories`.
- Created the main router for categories, wiring up all route handlers and OpenAPI route definitions.

**Validation and Schemas**
- Added Zod schemas for category and subcategory base models, selection (with related entities), creation, and update payloads, as well as strong type definitions for use throughout the backend.
- Added a Zod schema for validating reorder operations, ensuring correct payload structure for batch updates of display order.

**Database Model Enhancements**
- Updated the Drizzle ORM schema for categories and subcategories to match the new database constraints, including non-negative display order and explicit relationships to media and subcategories. [[1]](diffhunk://#diff-2930d21ef0e3acf1663ccbb65d5a67e0f0e4dd6ebccda3109d4d2c7ec8fc1b48L42-R43) [[2]](diffhunk://#diff-2930d21ef0e3acf1663ccbb65d5a67e0f0e4dd6ebccda3109d4d2c7ec8fc1b48L81-R99)

**Helper Utilities**
- Added a reusable Zod schema for reorder operations to the shared helpers module, supporting PATCH endpoints for ordering.
- Imported Zod in the helpers module to support schema definitions.